### PR TITLE
[SVC-672] Build AWS Session in BrokerConnection

### DIFF
--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -182,7 +182,7 @@ class KafkaAdminClient(object):
         'sasl_kerberos_service_name': 'kafka',
         'sasl_kerberos_domain_name': None,
         'sasl_oauth_token_provider': None,
-        'sasl_aws_msk_iam_session': None,
+        'sasl_aws_msk_iam_role_arn': None,
 
         # metrics configs
         'metric_reporters': [],

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -193,7 +193,7 @@ class KafkaClient(object):
         'sasl_kerberos_service_name': 'kafka',
         'sasl_kerberos_domain_name': None,
         'sasl_oauth_token_provider': None,
-        'sasl_aws_msk_iam_session': None,
+        'sasl_aws_msk_iam_role_arn': None,
     }
 
     def __init__(self, **configs):

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -86,7 +86,7 @@ except ImportError:
 
 # needed for AWS_MSK_IAM authentication:
 try:
-    from botocore.session import Session as BotoSession
+    from boto3 import Session as BotoSession
 except ImportError:
     # no botocore available, will disable AWS_MSK_IAM mechanism
     BotoSession = None
@@ -232,7 +232,7 @@ class BrokerConnection(object):
         'sasl_kerberos_service_name': 'kafka',
         'sasl_kerberos_domain_name': None,
         'sasl_oauth_token_provider': None,
-        'sasl_aws_msk_iam_session': BotoSession()
+        'sasl_aws_msk_iam_role_arn': None,
     }
     SECURITY_PROTOCOLS = ('PLAINTEXT', 'SSL', 'SASL_PLAINTEXT', 'SASL_SSL')
     SASL_MECHANISMS = ('PLAIN', 'GSSAPI', 'OAUTHBEARER', "SCRAM-SHA-256", "SCRAM-SHA-512", 'AWS_MSK_IAM')
@@ -573,7 +573,7 @@ class BrokerConnection(object):
         elif self.config['sasl_mechanism'].startswith("SCRAM-SHA-"):
             return self._try_authenticate_scram(future)
         elif self.config['sasl_mechanism'] == 'AWS_MSK_IAM':
-            return self._try_authenticate_aws_msk_iam(future, self.config["sasl_aws_msk_iam_session"])
+            return self._try_authenticate_aws_msk_iam(future, self.config["sasl_aws_msk_iam_role_arn"])
         else:
             return future.failure(
                 Errors.UnsupportedSaslMechanismError(
@@ -674,7 +674,22 @@ class BrokerConnection(object):
         log.info('%s: Authenticated as %s via PLAIN', self, self.config['sasl_plain_username'])
         return future.success(True)
 
-    def _try_authenticate_aws_msk_iam(self, future, session):
+    def _try_authenticate_aws_msk_iam(self, future, role_arn=None):
+        if role_arn:
+            client = BotoSession().client('sts')
+            assume_role = client.assume_role(
+                RoleArn=role_arn,
+                RoleSessionName="kafka-python"
+            )
+            credentials = assume_role['Credentials']
+            session = BotoSession(
+                aws_access_key_id=credentials['AccessKeyId'],
+                aws_secret_access_key=credentials['SecretAccessKey'],
+                aws_session_token=credentials['SessionToken'],
+            )
+        else:
+            session = BotoSession()
+
         credentials = session.get_credentials().get_frozen_credentials()
         client = AwsMskIamClient(
             host=self.host,

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -306,7 +306,7 @@ class KafkaConsumer(six.Iterator):
         'sasl_kerberos_service_name': 'kafka',
         'sasl_kerberos_domain_name': None,
         'sasl_oauth_token_provider': None,
-        'sasl_aws_msk_iam_session': None,
+        'sasl_aws_msk_iam_role_arn': None,
         'legacy_iterator': False, # enable to revert to < 1.4.7 iterator
         'kafka_client': KafkaClient,
     }

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -329,7 +329,7 @@ class KafkaProducer(object):
         'metrics_sample_window_ms': 30000,
         'selector': selectors.DefaultSelector,
         'sasl_mechanism': None,
-        'sasl_aws_msk_iam_session': None,
+        'sasl_aws_msk_iam_role_arn': None,
         'sasl_plain_username': None,
         'sasl_plain_password': None,
         'sasl_kerberos_service_name': 'kafka',


### PR DESCRIPTION
In this PR:

* The AWS Session is built when the BrokerConnection needs it.
* The `sasl_aws_msk_iam_session` parameter was removed.
* A new `sasl_aws_msk_iam_role_arn` parameter was added: When this parameter has a value, the role indicated is assumed and the credentials to use to create a Session object are those provided by the assumed role.
* It was not necessary to design and implement a mechanism to renew tokens. When the BrokerConnection needs to establish a new connection, it will get a fresh session object.
* The `region_name` was not included in the creation of Session objects or STS clients. Also, the default session object is created without any parameter (region, aws_access_key_id, etc). We should provide these parameters as environment variables.   

The following Alexandria image was built including this version of the library, in case you wan't to run some tests:

```
quay.io/reciprocity/alexandria:2022-01-14_17-43-39_svc_672_upgrade_kafka_connection_build_4a1ed9e
```